### PR TITLE
Use teaserlist

### DIFF
--- a/events.html
+++ b/events.html
@@ -12,7 +12,7 @@ title: Workshops
 
         <div class="col-md-6">
 
-          <a href="{{site.baseurl}}{{post.url}}"><img src="{{site.baseurl}}/img/blog/{{post.teaserlatest}}" alt="event"/></a>
+          <a href="{{site.baseurl}}{{post.url}}"><img src="{{site.baseurl}}/img/blog/{{post.teaserlist}}" alt="event"/></a>
 
         </div>  <!-- col-->
 


### PR DESCRIPTION
Hi @viktorsmari 

This closes issue #40 

Yes, we can just use 'teaserlist' instead of both. Actually, it's better since many posts don't have file name value for 'teaserlatest'. 

I also create a new template, change the field name to "Featured Image" and made the template default whenever users create a new post on Forestry.

Thanks